### PR TITLE
Added options page for AutoRunCustom tool.

### DIFF
--- a/AutoRunCustomTool/AutoRunCustomTool.csproj
+++ b/AutoRunCustomTool/AutoRunCustomTool.csproj
@@ -64,6 +64,9 @@
     <Compile Include="Guids.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="AutoRunCustomToolPackage.cs" />
+    <Compile Include="Options\OptionsPageGrid.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyExtender.cs" />
     <Compile Include="PropertyExtenderProvider.cs" />

--- a/AutoRunCustomTool/AutoRunCustomToolPackage.cs
+++ b/AutoRunCustomTool/AutoRunCustomToolPackage.cs
@@ -113,7 +113,7 @@ namespace ThomasLevesque.AutoRunCustomTool
             else
             {
                 string curExtension = "*" + Path.GetExtension(docFullPath).ToLower();
-                HashSet<string> extensions = new HashSet<string>(page.ListenToExtension.ToLower().Split(';'));
+                string[] extensions = page.ListenToExtension.ToLower().Split(';');
 
                 if (extensions.Contains(curExtension))
                     targets.AddRange(page.ToolToRun.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));

--- a/AutoRunCustomTool/AutoRunCustomToolPackage.cs
+++ b/AutoRunCustomTool/AutoRunCustomToolPackage.cs
@@ -79,7 +79,7 @@ namespace ThomasLevesque.AutoRunCustomTool
             
             string customTool = GetPropertyValue(docItem, "CustomTool") as string;
 
-            bool useGlobalOption = !string.IsNullOrEmpty(page.ListenToExtension) && !string.IsNullOrEmpty(page.ToolToRun) && string.IsNullOrEmpty(customTool);
+            bool useGlobalOption = !string.IsNullOrEmpty(page.TriggerExtenstions) && !string.IsNullOrEmpty(page.TargetFiles) && string.IsNullOrEmpty(customTool);
 
             if (customTool == "AutoRunCustomTool")
             {
@@ -113,10 +113,10 @@ namespace ThomasLevesque.AutoRunCustomTool
             else
             {
                 string curExtension = "*" + Path.GetExtension(docFullPath).ToLower();
-                string[] extensions = page.ListenToExtension.ToLower().Split(';');
+                string[] extensions = page.TriggerExtenstions.ToLower().Split(';');
 
                 if (extensions.Contains(curExtension))
-                    targets.AddRange(page.ToolToRun.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
+                    targets.AddRange(page.TargetFiles.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
             }
 
 

--- a/AutoRunCustomTool/Options/OptionsPageGrid.cs
+++ b/AutoRunCustomTool/Options/OptionsPageGrid.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.VisualStudio.Shell;
+using System.ComponentModel;
+
+namespace ThomasLevesque.AutoRunCustomTool.Options
+{
+    public class OptionsPageGrid : DialogPage
+    {
+        [Category("AutoRunCustomTool")]
+        [DisplayName("Extensions")]
+        [Description("What extension(s) to run the custom tool on")]
+        public string ListenToExtension { get; set; }
+
+        [Category("AutoRunCustomTool")]
+        [DisplayName("File to run tool on")]
+        [Description("The file that we should trigger a custom tool on save")]
+        public string ToolToRun { get; set; }
+    }
+}

--- a/AutoRunCustomTool/Options/OptionsPageGrid.cs
+++ b/AutoRunCustomTool/Options/OptionsPageGrid.cs
@@ -6,13 +6,13 @@ namespace ThomasLevesque.AutoRunCustomTool.Options
     public class OptionsPageGrid : DialogPage
     {
         [Category("AutoRunCustomTool")]
-        [DisplayName("Extensions")]
-        [Description("What extension(s) to run the custom tool on")]
-        public string ListenToExtension { get; set; }
+        [DisplayName("Trigger on extensions")]
+        [Description("What extension(s) trigger \"Target files\" to run custom tools")]
+        public string TriggerExtenstions { get; set; }
 
         [Category("AutoRunCustomTool")]
-        [DisplayName("File to run tool on")]
-        [Description("The file that we should trigger a custom tool on save")]
-        public string ToolToRun { get; set; }
+        [DisplayName("Target files")]
+        [Description("The files to trigger custom tools on, relative to project path")]
+        public string TargetFiles { get; set; }
     }
 }


### PR DESCRIPTION
You can define globally what extensions run another custom tool ( or several ). Use the project directory path when the global setting is used. Use the global setting only if there is no option defined on the project item.

Since i am using this in conjuction with TypescriptHtmlPackager. I wanted a way to run a custom tool when any .html file is saved.

The options page will be available in: Tools -> Options -> AutoRunCustomTool.